### PR TITLE
Switch on several CRYPTO options when Tempesta is configured.

### DIFF
--- a/security/tempesta/Kconfig
+++ b/security/tempesta/Kconfig
@@ -2,6 +2,10 @@ config SECURITY_TEMPESTA
 	bool "Tempesta FW Support"
 	depends on SECURITY && NET && INET
 	select SECURITY_NETWORK
+	select CRYPTO
+	select CRYPTO_HMAC
+	select CRYPTO_SHA1
+	select CRYPTO_SHA1_SSSE3
 	default y
 	help
 	  This selects Tempesta FW security module.


### PR DESCRIPTION
HMAC and SHA1 are used now for Tempesta sticky cookie.