### PR TITLE
Supporting function for implementation of Tempesta ss_sock_create().

### DIFF
--- a/include/linux/net.h
+++ b/include/linux/net.h
@@ -185,6 +185,8 @@ struct net_proto_family {
 	struct module	*owner;
 };
 
+extern const struct net_proto_family *get_proto_family(int family);
+
 struct iovec;
 struct kvec;
 

--- a/net/socket.c
+++ b/net/socket.c
@@ -158,6 +158,12 @@ static const struct file_operations socket_file_ops = {
 static DEFINE_SPINLOCK(net_family_lock);
 static const struct net_proto_family __rcu *net_families[NPROTO] __read_mostly;
 
+const struct net_proto_family *get_proto_family(int family)
+{
+	return rcu_dereference(net_families[family]);
+}
+EXPORT_SYMBOL(get_proto_family);
+
 /*
  *	Statistics counters of the socket lists
  */


### PR DESCRIPTION
This kernel patch is necessary for `ss_sock_create()` to work. It needs to be included as soon as `ab-connect` branch in Tempesta is merged.