### PR TITLE
Use SKB reference counting when freeing SKBs in socket's TX path

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -631,6 +631,7 @@ static inline struct rtable *skb_rtable(const struct sk_buff *skb)
 }
 
 extern void kfree_skb(struct sk_buff *skb);
+extern void kfree_skb_untraced(struct sk_buff *skb);
 extern void kfree_skb_list(struct sk_buff *segs);
 extern void skb_tx_error(struct sk_buff *skb);
 extern void consume_skb(struct sk_buff *skb);

--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -1417,7 +1417,7 @@ static inline void sk_wmem_free_skb(struct sock *sk, struct sk_buff *skb)
 	sock_set_flag(sk, SOCK_QUEUE_SHRUNK);
 	sk->sk_wmem_queued -= skb->truesize;
 	sk_mem_uncharge(sk, skb->truesize);
-	__kfree_skb(skb);
+	kfree_skb_untraced(skb);
 }
 
 /* Used by processes to "lock" a socket state, so that


### PR DESCRIPTION
In the socket layer Linux considers itself a lone owner of SKBs that are
in RX and TX queues. SKBs are taken out from RX queue and passed to Tempesta.
Then Tempesta puts then out to TX queue, and from that moment the SKBs are
owned by both the kernel and Tempesta. Make sure the kernel knows that and
uses kfree_skb() instead of __kfree_skb() in the socket's TX path.